### PR TITLE
Support replica sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,26 @@ func TestSomething(t *testing.T) {
 }
 ```
 
+Spin up a replica set server:
+
+```go
+var mongoServer memongo.Server;
+
+func TestMain(m *testing.M) {
+  mongoServer, err = memongo.StartWitOptions(&memongo.Options{MongoVersion: "4.2.1", ShouldUseReplica: true})
+  if (err != nil) {
+    log.Fatal(err)
+  }
+  defer mongoServer.Stop()
+
+  os.Exit(m.Run())
+}
+
+func TestSomething(t *testing.T) {
+  connectAndDoStuff(mongoServer.URI(), memongo.RandomDatabase())
+}
+```
+
 # How it works
 
 Behind the scenes, when you run `Start()`, a few things are happening:

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Spin up a replica set server:
 var mongoServer memongo.Server;
 
 func TestMain(m *testing.M) {
-  mongoServer, err = memongo.StartWitOptions(&memongo.Options{MongoVersion: "4.2.1", ShouldUseReplica: true})
+  mongoServer, err = memongo.StartWithOptions(&memongo.Options{MongoVersion: "4.2.1", ShouldUseReplica: true})
   if (err != nil) {
     log.Fatal(err)
   }

--- a/config.go
+++ b/config.go
@@ -106,22 +106,12 @@ func (opts *Options) fillDefaults() error {
 	}
 
 	if opts.Port == 0 {
-		// MongoDB after version 4 correctly reports what port it's running on if
-		// we tell it to run on port 0, which is ideal -- we just start it on port
-		// 0, the OS assigns a port, and mongo reports in the logs what port it
-		// got.
-		//
-		// For earlier versions, mongo just print "waiting for connections on port 0"
-		// which is unhelpful. So we start up a server and see what port we get,
-		// then shut down that server
-		if opts.MongoVersion == "" || parseMongoMajorVersion(opts.MongoVersion) < 4 {
-			port, err := getFreePort()
-			if err != nil {
-				return fmt.Errorf("error finding a free port: %s", err)
-			}
-
-			opts.Port = port
+		port, err := getFreePort()
+		if err != nil {
+			return fmt.Errorf("error finding a free port: %s", err)
 		}
+
+		opts.Port = port
 
 		if opts.StartupTimeout == 0 {
 			opts.StartupTimeout = 10 * time.Second

--- a/config.go
+++ b/config.go
@@ -17,6 +17,10 @@ import (
 
 // Options is the configuration options for a launched MongoDB binary
 type Options struct {
+	// ShouldUseReplica indicates whether a replica should be used. If this is not specified,
+	// no replica will be used and mongo server will be run as standalone.
+	ShouldUseReplica bool
+
 	// Port to run MongoDB on. If this is not specified, a random (OS-assigned)
 	// port will be used
 	Port int

--- a/memongo.go
+++ b/memongo.go
@@ -143,7 +143,7 @@ func StartWithOptions(opts *Options) (*Server, error) {
 	// ---------- START OF REPLICA CODE ----------
 	if opts.ShouldUseReplica {
 		//nolint:gosec
-		replicaSetCommand := exec.Command("bash", "-c", "mongo", "--port", fmt.Sprintf("%d", opts.Port), "--retryWrites", "--eval", "\"rs.initiate()\"")
+		replicaSetCommand := exec.Command("mongo", "--port", fmt.Sprintf("%d", opts.Port), "--retryWrites", "--eval", "\"rs.initiate()\"")
 		replicaSetCommand.Stdout = stdoutHandler
 		replicaSetCommand.Stderr = stderrHandler(logger)
 

--- a/memongo.go
+++ b/memongo.go
@@ -64,7 +64,7 @@ func StartWithOptions(opts *Options) (*Server, error) {
 	cmd := exec.Command(binPath, "--storageEngine", "ephemeralForTest", "--dbpath", dbDir, "--port", strconv.Itoa(opts.Port))
 	if opts.ShouldUseReplica {
 		//nolint:gosec
-		cmd = exec.Command(binPath, "--storageEngine", "wiredTiger", "--dbpath", dbDir, "--port", strconv.Itoa(opts.Port), "--replSet", "rs0", "--bind_ip", "localhost")
+		cmd = exec.Command(binPath, "--storageEngine", "ephemeralForTest", "--dbpath", dbDir, "--port", strconv.Itoa(opts.Port), "--replSet", "rs0", "--bind_ip", "localhost")
 	}
 
 	stdoutHandler, startupErrCh, startupPortCh := stdoutHandler(logger)
@@ -143,7 +143,9 @@ func StartWithOptions(opts *Options) (*Server, error) {
 	// ---------- START OF REPLICA CODE ----------
 	if opts.ShouldUseReplica {
 		//nolint:gosec
-		replicaSetCommand := exec.Command("mongo", "--port", fmt.Sprintf("%d", opts.Port), "--retryWrites", "--eval", "\"rs.initiate()\"")
+		mongoCommand := fmt.Sprintf("mongo --port %d --retryWrites --eval \"rs.initiate()\"", opts.Port)
+		//nolint:gosec
+		replicaSetCommand := exec.Command("bash", "-c", mongoCommand)
 		replicaSetCommand.Stdout = stdoutHandler
 		replicaSetCommand.Stderr = stderrHandler(logger)
 

--- a/memongo_test.go
+++ b/memongo_test.go
@@ -35,7 +35,7 @@ func TestDefaultOptions(t *testing.T) {
 }
 
 func TestWithReplica(t *testing.T) {
-	versions := []string{"3.6.13", "4.0.13", "4.2.1"}
+	versions := []string{"4.4.7", "5.0.0"}
 
 	for _, version := range versions {
 		t.Run(version, func(t *testing.T) {

--- a/memongo_test.go
+++ b/memongo_test.go
@@ -2,6 +2,7 @@ package memongo_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/tryvium-travels/memongo"
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
 )
 
 func TestDefaultOptions(t *testing.T) {
@@ -28,6 +30,31 @@ func TestDefaultOptions(t *testing.T) {
 			require.NoError(t, err)
 
 			require.NoError(t, client.Ping(context.Background(), nil))
+		})
+	}
+}
+
+func TestWithReplica(t *testing.T) {
+	versions := []string{"3.6.13", "4.0.13", "4.2.1"}
+
+	for _, version := range versions {
+		t.Run(version, func(t *testing.T) {
+			server, err := memongo.StartWithOptions(&memongo.Options{
+				MongoVersion:     version,
+				LogLevel:         memongolog.LogLevelDebug,
+				ShouldUseReplica: true,
+			})
+			require.NoError(t, err)
+			defer server.Stop()
+
+			uri := fmt.Sprintf("%s%s", server.URI(), "/retryWrites=false")
+			client, err := mongo.Connect(context.Background(), options.Client().ApplyURI(uri))
+			if err != nil {
+				t.Logf("err Connect: %v", err)
+			}
+
+			require.NoError(t, err)
+			require.NoError(t, client.Ping(context.Background(), readpref.Primary()))
 		})
 	}
 }


### PR DESCRIPTION
I saw that [this PR](https://github.com/benweissmann/memongo/pull/6) was inactive and it had a feature I really need (replica sets, to support transactions).

I copied the code over with few modifications. One issue I'd like to address is the fact that the command uses a hardcoded `mongo` location instead of using the binary that comes with the downloaded MongoDB release archive.