### PR TITLE
Copy mongod binary from /tmp to cache if cross-device link error occurs during rename

### DIFF
--- a/mongobin/getOrDownload_test.go
+++ b/mongobin/getOrDownload_test.go
@@ -46,3 +46,42 @@ func TestGetOrDownload(t *testing.T) {
 
 	assert.Equal(t, stat.ModTime(), stat2.ModTime())
 }
+
+func TestGetOrDownloadDifferentFilesystems(t *testing.T) {
+	mongobin.Afs = afero.Afero{Fs: afero.NewMemMapFs()}
+
+	spec := mongobin.DownloadSpec{
+		Version:        "4.0.5",
+		Platform:       "osx",
+		SSLBuildNeeded: true,
+		Arch:           "x86_64",
+	}
+
+	// Initialize the cache in a different filesystem
+	cacheFs := afero.Afero{Fs: afero.NewMemMapFs()}
+	cacheDir, err := cacheFs.TempDir("", "")
+	require.NoError(t, err)
+
+	// First call should download the file
+	path, err := mongobin.GetOrDownloadMongod(spec.GetDownloadURL(), cacheDir, memongolog.New(nil, memongolog.LogLevelDebug))
+	require.NoError(t, err)
+
+	assert.Equal(t, cacheDir+"/mongodb-osx-ssl-x86_64-4_0_5_tgz_d50ef2155b/mongod", path)
+
+	stat, err := mongobin.Afs.Stat(path)
+	require.NoError(t, err)
+
+	assert.True(t, stat.Size() > 50000000)
+	assert.True(t, stat.Mode()&0100 != 0)
+
+	// Second call should used the cached file
+	path2, err := mongobin.GetOrDownloadMongod(spec.GetDownloadURL(), cacheDir, memongolog.New(nil, memongolog.LogLevelDebug))
+	require.NoError(t, err)
+
+	assert.Equal(t, path, path2)
+
+	stat2, err := mongobin.Afs.Stat(path2)
+	require.NoError(t, err)
+
+	assert.Equal(t, stat.ModTime(), stat2.ModTime())
+}


### PR DESCRIPTION
Resolves #5 

I wasn't able to reproduce the error by creating a second memory-mapped filesystem for the cacheDir in the test, not sure why it was able to copy that way.