### PR TITLE
Fix bug with retryableWrites

### DIFF
--- a/memongo.go
+++ b/memongo.go
@@ -64,7 +64,7 @@ func StartWithOptions(opts *Options) (*Server, error) {
 	cmd := exec.Command(binPath, "--storageEngine", "ephemeralForTest", "--dbpath", dbDir, "--port", strconv.Itoa(opts.Port))
 	if opts.ShouldUseReplica {
 		//nolint:gosec
-		cmd = exec.Command(binPath, "--storageEngine", "ephemeralForTest", "--dbpath", dbDir, "--port", strconv.Itoa(opts.Port), "--replSet", "rs0", "--bind_ip", "localhost")
+		cmd = exec.Command(binPath, "--storageEngine", "wiredTiger", "--dbpath", dbDir, "--port", strconv.Itoa(opts.Port), "--replSet", "rs0", "--bind_ip", "localhost")
 	}
 
 	stdoutHandler, startupErrCh, startupPortCh := stdoutHandler(logger)


### PR DESCRIPTION
I changed the storage engine in my last PR and did not know that doing so would cause errors like this:

```
this MongoDB deployment does not support retryable writes. Please add retryWrites=false to your connection string
```

This PR reverts that change.