### PR TITLE
Expose Auth parameters to memongo

### DIFF
--- a/config.go
+++ b/config.go
@@ -49,6 +49,10 @@ type Options struct {
 	// How long to wait for mongod to start up and report a port number. Does
 	// not include download time, only startup time. Defaults to 10 seconds.
 	StartupTimeout time.Duration
+
+	// If set, pass the --auth flag to mongod. This will allow tests to setup
+	// authentication.
+	Auth bool
 }
 
 func (opts *Options) fillDefaults() error {

--- a/memongo.go
+++ b/memongo.go
@@ -68,6 +68,20 @@ func StartWithOptions(opts *Options) (*Server, error) {
 
 	if opts.Auth {
 		args = append(args, "--auth")
+		// A keyfile needs to be specified if auth and a replicaset are used
+		if opts.ShouldUseReplica {
+			tmpFile, err := ioutil.TempFile("", "keyfile")
+			// This library is specifically intended for ephemeral mongo
+			// databases so we don't need a lot of security here, however
+			// if you're reading this file trying to figure out how to generate
+			// a keyfile, please see the official MongoDB documentation on how
+			// to do this correctly and securely for a production environment.
+			tmpFile.Write([]byte("insecurekeyfile"))
+			if err != nil {
+				return nil, err
+			}
+			args = append(args, "--keyFile", tmpFile.Name())
+		}
 	}
 
 	args = append(args, []string{"--storageEngine", engine}...)

--- a/memongo_test.go
+++ b/memongo_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tryvium-travels/memongo/memongolog"
 
 	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
@@ -55,6 +56,60 @@ func TestWithReplica(t *testing.T) {
 
 			require.NoError(t, err)
 			require.NoError(t, client.Ping(context.Background(), readpref.Primary()))
+		})
+	}
+}
+
+func TestWithAuth(t *testing.T) {
+	versions := []string{"4.4.7", "5.0.0"}
+
+	for _, version := range versions {
+		t.Run(version, func(t *testing.T) {
+			server, err := memongo.StartWithOptions(&memongo.Options{
+				MongoVersion: version,
+				LogLevel:     memongolog.LogLevelDebug,
+				Auth:         true,
+			})
+			require.NoError(t, err)
+			defer server.Stop()
+
+			client, err := mongo.Connect(context.Background(), options.Client().ApplyURI(server.URI()))
+			require.NoError(t, err)
+
+			require.NoError(t, client.Ping(context.Background(), nil))
+
+			// Create a default user admin / 12345 to test auth.
+			admin := client.Database("admin")
+			res := admin.RunCommand(context.Background(), bson.D{
+				{Key: "createUser", Value: "admin"},
+				{Key: "pwd", Value: "12345"},
+				{Key: "roles", Value: []bson.M{
+					{"role": "userAdminAnyDatabase", "db": "admin"},
+				}},
+			})
+			require.NoError(t, res.Err())
+
+			// Verify we cannot connect without auth
+			client2, err := mongo.Connect(context.Background(), options.Client().ApplyURI(server.URI()))
+			require.NoError(t, err)
+
+			require.NoError(t, client2.Ping(context.Background(), nil))
+			_, err = client2.ListDatabaseNames(context.Background(), bson.D{})
+			require.EqualError(t, err, "(Unauthorized) command listDatabases requires authentication")
+
+			// Now connect again with auth
+			opts := options.Client().ApplyURI(server.URI())
+			opts.Auth = &options.Credential{
+				Username:   "admin",
+				Password:   "12345",
+				AuthSource: "admin",
+			}
+			client3, err := mongo.Connect(context.Background(), opts)
+			require.NoError(t, err)
+
+			require.NoError(t, client3.Ping(context.Background(), nil))
+			_, err = client3.ListDatabaseNames(context.Background(), bson.D{})
+			require.NoError(t, err)
 		})
 	}
 }

--- a/memongo_test.go
+++ b/memongo_test.go
@@ -113,3 +113,62 @@ func TestWithAuth(t *testing.T) {
 		})
 	}
 }
+
+func TestWithReplicaAndAuth(t *testing.T) {
+	versions := []string{"4.4.7", "5.0.0"}
+
+	for _, version := range versions {
+		t.Run(version, func(t *testing.T) {
+			server, err := memongo.StartWithOptions(&memongo.Options{
+				MongoVersion:     version,
+				LogLevel:         memongolog.LogLevelDebug,
+				ShouldUseReplica: true,
+				Auth:             true,
+			})
+			require.NoError(t, err)
+			defer server.Stop()
+
+			uri := fmt.Sprintf("%s%s", server.URI(), "/retryWrites=false")
+			client, err := mongo.Connect(context.Background(), options.Client().ApplyURI(uri))
+			if err != nil {
+				t.Logf("err Connect: %v", err)
+			}
+
+			require.NoError(t, err)
+			require.NoError(t, client.Ping(context.Background(), readpref.Primary()))
+
+			// Create a default user admin / 12345 to test auth.
+			admin := client.Database("admin")
+			res := admin.RunCommand(context.Background(), bson.D{
+				{Key: "createUser", Value: "admin"},
+				{Key: "pwd", Value: "12345"},
+				{Key: "roles", Value: []bson.M{
+					{"role": "userAdminAnyDatabase", "db": "admin"},
+				}},
+			})
+			require.NoError(t, res.Err())
+
+			// Verify we cannot connect without auth
+			client2, err := mongo.Connect(context.Background(), options.Client().ApplyURI(server.URI()))
+			require.NoError(t, err)
+
+			require.NoError(t, client2.Ping(context.Background(), nil))
+			_, err = client2.ListDatabaseNames(context.Background(), bson.D{})
+			require.EqualError(t, err, "(Unauthorized) command listDatabases requires authentication")
+
+			// Now connect again with auth
+			opts := options.Client().ApplyURI(server.URI())
+			opts.Auth = &options.Credential{
+				Username:   "admin",
+				Password:   "12345",
+				AuthSource: "admin",
+			}
+			client3, err := mongo.Connect(context.Background(), opts)
+			require.NoError(t, err)
+
+			require.NoError(t, client3.Ping(context.Background(), nil))
+			_, err = client3.ListDatabaseNames(context.Background(), bson.D{})
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
# Details

Add the ability to expose the `--auth` flag easily to tests. I'm working with some software reliant on testing specific conditions related to whether a user is authorized on a MongoDB instance (or not) and this parameter didn't seem passible before. With this addition, it's still up to the test author to create users/roles (but some examples are shown in the included tests).

I've tested this with both the standalone and ReplicaSet mode, which requires the extra `--keyfile` argument. For simplicity and not to add any dependencies to `memongo` I opted to use a static keyfile as this should **never** be used in production.

I didn't see any contribution guidelines in the repo so I hope I've opened this in the correct format.