### PR TITLE
Support arm64 mongo releases automatic download

### DIFF
--- a/mongobin/downloadSpec_test.go
+++ b/mongobin/downloadSpec_test.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	testMongoVersion   = "4.0.5"
-	latestMongoVersion = "6.0.0"
+	latestMongoVersion = "6.0.4"
 )
 
 func TestMakeDownloadSpec(t *testing.T) {
@@ -46,6 +46,19 @@ func TestMakeDownloadSpec(t *testing.T) {
 				OSName:         "",
 			},
 		},
+		"arm64 mac and newer mongo": {
+			goOs:         "darwin",
+			goArch:       "arm64",
+			mongoVersion: latestMongoVersion,
+
+			expectedSpec: &mongobin.DownloadSpec{
+				Version:        latestMongoVersion,
+				Platform:       "osx",
+				SSLBuildNeeded: false,
+				Arch:           "arm64",
+				OSName:         "",
+			},
+		},
 		"windows": {
 			goOs: "windows",
 
@@ -60,6 +73,19 @@ func TestMakeDownloadSpec(t *testing.T) {
 				Platform:       "linux",
 				SSLBuildNeeded: false,
 				Arch:           "x86_64",
+				OSName:         "ubuntu2204",
+			},
+		},
+		"arm64 ubuntu 22.04 newer mongo": {
+			mongoVersion: latestMongoVersion,
+			etcFolder:    "ubuntu2204",
+			goArch:       "arm64",
+
+			expectedSpec: &mongobin.DownloadSpec{
+				Version:        latestMongoVersion,
+				Platform:       "linux",
+				SSLBuildNeeded: false,
+				Arch:           "aarch64",
 				OSName:         "ubuntu2204",
 			},
 		},
@@ -87,6 +113,19 @@ func TestMakeDownloadSpec(t *testing.T) {
 				OSName:         "ubuntu2004",
 			},
 		},
+		"arm64 ubuntu 20.04 and newer mongo": {
+			mongoVersion: latestMongoVersion,
+			etcFolder:    "ubuntu2004",
+			goArch:       "arm64",
+
+			expectedSpec: &mongobin.DownloadSpec{
+				Version:        latestMongoVersion,
+				Platform:       "linux",
+				SSLBuildNeeded: false,
+				Arch:           "aarch64",
+				OSName:         "ubuntu2004",
+			},
+		},
 		"ubuntu 18.04": {
 			mongoVersion: testMongoVersion,
 			etcFolder:    "ubuntu1804",
@@ -96,6 +135,19 @@ func TestMakeDownloadSpec(t *testing.T) {
 				Platform:       "linux",
 				SSLBuildNeeded: false,
 				Arch:           "x86_64",
+				OSName:         "ubuntu1804",
+			},
+		},
+		"arm64 ubuntu 18.04 and newer mongo": {
+			mongoVersion: latestMongoVersion,
+			etcFolder:    "ubuntu1804",
+			goArch:       "arm64",
+
+			expectedSpec: &mongobin.DownloadSpec{
+				Version:        latestMongoVersion,
+				Platform:       "linux",
+				SSLBuildNeeded: false,
+				Arch:           "aarch64",
 				OSName:         "ubuntu1804",
 			},
 		},
@@ -132,6 +184,19 @@ func TestMakeDownloadSpec(t *testing.T) {
 				Platform:       "linux",
 				SSLBuildNeeded: false,
 				Arch:           "x86_64",
+				OSName:         "ubuntu1604",
+			},
+		},
+		"arm64 ubuntu 16.04": {
+			mongoVersion: testMongoVersion,
+			etcFolder:    "ubuntu1604",
+			goArch:       "arm64",
+
+			expectedSpec: &mongobin.DownloadSpec{
+				Version:        testMongoVersion,
+				Platform:       "linux",
+				SSLBuildNeeded: false,
+				Arch:           "arm64",
 				OSName:         "ubuntu1604",
 			},
 		},
@@ -339,6 +404,19 @@ func TestMakeDownloadSpec(t *testing.T) {
 				OSName:         "amazon2",
 			},
 		},
+		"ARM64 Amazon Linux 2 and newer mongo": {
+			mongoVersion: latestMongoVersion,
+			etcFolder:    "amazon2",
+			goArch:       "arm64",
+
+			expectedSpec: &mongobin.DownloadSpec{
+				Version:        latestMongoVersion,
+				Platform:       "linux",
+				SSLBuildNeeded: false,
+				Arch:           "aarch64",
+				OSName:         "amazon2",
+			},
+		},
 		"Amazon Linux 2 older mongo": {
 			mongoVersion: "3.6.5",
 			etcFolder:    "amazon2",
@@ -427,6 +505,61 @@ func TestMakeDownloadSpec(t *testing.T) {
 				Arch:           "x86_64",
 				OSName:         "",
 			},
+		},
+		"MongoDB Unsupported arch for version": {
+			mongoVersion: "3.3.0",
+			goArch:       "arm64",
+
+			expectedError: "memongo does not support automatic downloading on your system: arm64 support was introduced in Mongo 3.4.0",
+		},
+		"MongoDB Unsupported newer version for arm64 ubuntu1604": {
+			mongoVersion: "6.0.0",
+			etcFolder:    "ubuntu1604",
+			goArch:       "arm64",
+
+			expectedError: "memongo does not support automatic downloading on your system: Mongo doesn't support your environment, ubuntu1604/arm64, on version 6.0.0",
+		},
+		"MongoDB Unsupported older version for arm64 ubuntu1804": {
+			mongoVersion: "4.1.0",
+			etcFolder:    "ubuntu1804",
+			goArch:       "arm64",
+
+			expectedError: "memongo does not support automatic downloading on your system: Mongo doesn't support your environment, ubuntu1804/arm64, on version 4.1.0",
+		},
+		"MongoDB Unsupported older version for arm64 ubuntu2004": {
+			mongoVersion: "4.1.0",
+			etcFolder:    "ubuntu2004",
+			goArch:       "arm64",
+
+			expectedError: "memongo does not support automatic downloading on your system: Mongo doesn't support your environment, ubuntu2004/arm64, on version 4.1.0",
+		},
+		"MongoDB Unsupported older version for arm64 ubuntu2204": {
+			mongoVersion: "4.1.0",
+			etcFolder:    "ubuntu2204",
+			goArch:       "arm64",
+
+			expectedError: "memongo does not support automatic downloading on your system: Mongo doesn't support your environment, ubuntu2204/arm64, on version 4.1.0",
+		},
+		"MongoDB Unsupported older version for arm64 amazon2": {
+			mongoVersion: "4.1.0",
+			etcFolder:    "amazon2",
+			goArch:       "arm64",
+
+			expectedError: "memongo does not support automatic downloading on your system: Mongo doesn't support your environment, amazon2/arm64, on version 4.1.0",
+		},
+		"MongoDB Unsupported older version for arm64 rhel82": {
+			mongoVersion: "4.1.0",
+			etcFolder:    "rhel82",
+			goArch:       "arm64",
+
+			expectedError: "memongo does not support automatic downloading on your system: Mongo doesn't support your environment, linux/arm64, on version 4.1.0",
+		},
+		"MongoDB Unsupported version for arm mac": {
+			mongoVersion: "4.1.0",
+			goOs:         "darwin",
+			goArch:       "arm64",
+
+			expectedError: "memongo does not support automatic downloading on your system: Mongo doesn't support your environment, osx/arm64, on version 4.1.0",
 		},
 		"MongoDB 3.0": {
 			mongoVersion: "3.0.2",

--- a/mongobin/downloadURL_test.go
+++ b/mongobin/downloadURL_test.go
@@ -49,6 +49,17 @@ func TestGetDownloadURL(t *testing.T) {
 			},
 			expectedURL: "https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-VERSION.tgz",
 		},
+		"arm64 mac": {
+			spec: &mongobin.DownloadSpec{
+				Platform: "osx",
+				Arch:     "arm64",
+				OSName:   "",
+			},
+			mongoVersions: []string{
+				"6.0.0",
+			},
+			expectedURL: "https://fastdl.mongodb.org/osx/mongodb-macos-arm64-VERSION.tgz",
+		},
 		"ubuntu 18.04": {
 			spec: &mongobin.DownloadSpec{
 				Platform: "linux",
@@ -57,6 +68,33 @@ func TestGetDownloadURL(t *testing.T) {
 			},
 			mongoVersions: []string{"4.0.1", "4.0.13", "4.2.1"},
 			expectedURL:   "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-VERSION.tgz",
+		},
+		"arm64 ubuntu 18.04": {
+			spec: &mongobin.DownloadSpec{
+				Platform: "linux",
+				Arch:     "aarch64",
+				OSName:   "ubuntu1804",
+			},
+			mongoVersions: []string{"4.2.1", "4.4.0", "6.0.0"},
+			expectedURL:   "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu1804-VERSION.tgz",
+		},
+		"arm64 ubuntu 20.04": {
+			spec: &mongobin.DownloadSpec{
+				Platform: "linux",
+				Arch:     "aarch64",
+				OSName:   "ubuntu2004",
+			},
+			mongoVersions: []string{"4.4.0", "6.0.0"},
+			expectedURL:   "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2004-VERSION.tgz",
+		},
+		"arm64 ubuntu 22.04": {
+			spec: &mongobin.DownloadSpec{
+				Platform: "linux",
+				Arch:     "aarch64",
+				OSName:   "ubuntu2204",
+			},
+			mongoVersions: []string{"6.0.4"},
+			expectedURL:   "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu2204-VERSION.tgz",
 		},
 		"ubuntu 16.04": {
 			spec: &mongobin.DownloadSpec{
@@ -68,6 +106,17 @@ func TestGetDownloadURL(t *testing.T) {
 				"3.2.7", "3.4.0", "3.4.19", "3.6.0", "3.6.10", "4.0.0", "4.0.13", "4.2.1",
 			},
 			expectedURL: "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-VERSION.tgz",
+		},
+		"arm64 ubuntu 16.04": {
+			spec: &mongobin.DownloadSpec{
+				Platform: "linux",
+				Arch:     "arm64",
+				OSName:   "ubuntu1604",
+			},
+			mongoVersions: []string{
+				"3.4.0", "3.4.19", "3.6.0", "3.6.10", "4.0.0", "4.0.13",
+			},
+			expectedURL: "https://fastdl.mongodb.org/linux/mongodb-linux-arm64-ubuntu1604-VERSION.tgz",
 		},
 		"ubuntu 14.04": {
 			spec: &mongobin.DownloadSpec{
@@ -88,6 +137,15 @@ func TestGetDownloadURL(t *testing.T) {
 			},
 			mongoVersions: mongoVersionsToTest,
 			expectedURL:   "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-suse12-VERSION.tgz",
+		},
+		"ARM64 RHEL 8.2": {
+			spec: &mongobin.DownloadSpec{
+				Platform: "linux",
+				Arch:     "aarch64",
+				OSName:   "rhel82",
+			},
+			mongoVersions: []string{"4.4.4", "5.0.1", "6.0.4"},
+			expectedURL:   "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-rhel82-VERSION.tgz",
 		},
 		"RHEL 7": {
 			spec: &mongobin.DownloadSpec{
@@ -161,6 +219,15 @@ func TestGetDownloadURL(t *testing.T) {
 				"4.0.0", "4.0.13", "4.2.1",
 			},
 			expectedURL: "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-amazon2-VERSION.tgz",
+		},
+		"ARM64 Amazon Linux 2": {
+			spec: &mongobin.DownloadSpec{
+				Platform: "linux",
+				Arch:     "aarch64",
+				OSName:   "amazon2",
+			},
+			mongoVersions: []string{"4.4.4", "5.0.1", "6.0.4"},
+			expectedURL:   "https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-amazon2-VERSION.tgz",
 		},
 		"Other Linux": {
 			spec: &mongobin.DownloadSpec{


### PR DESCRIPTION
Add support for downloading arm64 mongo builds.

I went through the [release archive](https://www.mongodb.com/download-center/community/releases/archive) and constrained automatically downloading arm releases to only existing ones.

Although rhel82 is in the list of supported os'es, it can't be provisioned yet as `osNameFromOsRelease` can't parse that name.