### PR TITLE
fixed debian 11 download spec

### DIFF
--- a/mongobin/downloadSpec.go
+++ b/mongobin/downloadSpec.go
@@ -292,7 +292,7 @@ func osNameFromUbuntuRelease(majorVersion int, mongoVersion []int) string {
 }
 
 func osNameFromDebianRelease(majorVersion int, mongoVersion []int) string {
-	if majorVersion >= 11 && versionGTE(mongoVersion, []int{4, 2, 1}) {
+	if majorVersion >= 11 && versionGTE(mongoVersion, []int{5, 0, 8}) {
 		return "debian11"
 	}
 	if majorVersion >= 10 && versionGTE(mongoVersion, []int{4, 2, 1}) {


### PR DESCRIPTION
The debian 11 download spec is incorrect, there is no debian 11 builds for versions < 5.0.8 according to my observations. This means we can't use mongo 5.0.5 on our debian 11< systems.

This simple fix would solve this. (By looking at surrounding code, I am guessing that this was a copy-paste-error)

Closes #27 