### PR TITLE
fix mongo version

### DIFF
--- a/config.go
+++ b/config.go
@@ -8,7 +8,6 @@ import (
 	"path"
 	"runtime"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/tryvium-travels/memongo/memongolog"
@@ -141,20 +140,6 @@ func (opts *Options) getOrDownloadBinPath() (string, error) {
 	}
 
 	return binPath, nil
-}
-
-func parseMongoMajorVersion(version string) int {
-	strParts := strings.Split(version, ".")
-	if len(strParts) == 0 {
-		return 0
-	}
-
-	maj, err := strconv.Atoi(strParts[0])
-	if err != nil {
-		return 0
-	}
-
-	return maj
 }
 
 func getFreePort() (int, error) {

--- a/mongobin/downloadSpec.go
+++ b/mongobin/downloadSpec.go
@@ -2,7 +2,7 @@ package mongobin
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -213,7 +213,7 @@ func detectOSName(mongoVersion []int) string {
 
 	// We control etcRedhatRelease
 	//nolint:gosec
-	redhatRelease, redhatReleaseErr := ioutil.ReadFile(EtcRedhatRelease)
+	redhatRelease, redhatReleaseErr := os.ReadFile(EtcRedhatRelease)
 	if redhatReleaseErr == nil {
 		return osNameFromRedhatRelease(string(redhatRelease))
 	}
@@ -273,7 +273,7 @@ func osNameFromOsRelease(osRelease map[string]string, mongoVersion []int) string
 	return ""
 }
 func osNameFromUbuntuRelease(majorVersion int, mongoVersion []int) string {
-	if majorVersion >= 22 && versionGTE(mongoVersion, []int{4, 0, 1}) {
+	if majorVersion >= 22 && versionGTE(mongoVersion, []int{6, 0, 4}) {
 		return "ubuntu2204"
 	}
 	if majorVersion >= 20 && versionGTE(mongoVersion, []int{4, 0, 1}) {

--- a/mongobin/downloadSpec.go
+++ b/mongobin/downloadSpec.go
@@ -276,7 +276,7 @@ func osNameFromUbuntuRelease(majorVersion int, mongoVersion []int) string {
 	if majorVersion >= 22 && versionGTE(mongoVersion, []int{6, 0, 4}) {
 		return "ubuntu2204"
 	}
-	if majorVersion >= 20 && versionGTE(mongoVersion, []int{4, 0, 1}) {
+	if majorVersion >= 20 && versionGTE(mongoVersion, []int{4, 4, 0}) {
 		return "ubuntu2004"
 	}
 	if majorVersion >= 18 && versionGTE(mongoVersion, []int{4, 0, 1}) {

--- a/mongobin/downloadSpec_test.go
+++ b/mongobin/downloadSpec_test.go
@@ -98,7 +98,7 @@ func TestMakeDownloadSpec(t *testing.T) {
 				Platform:       "linux",
 				SSLBuildNeeded: false,
 				Arch:           "x86_64",
-				OSName:         "ubuntu2204",
+				OSName:         "ubuntu1804", // Ubuntu 22.04 is not supported by Mongo 4.0.5, so it falls back to Ubuntu 18.04
 			},
 		},
 		"ubuntu 20.04": {
@@ -110,7 +110,7 @@ func TestMakeDownloadSpec(t *testing.T) {
 				Platform:       "linux",
 				SSLBuildNeeded: false,
 				Arch:           "x86_64",
-				OSName:         "ubuntu2004",
+				OSName:         "ubuntu1804", // Ubuntu 20.04 is not supported by Mongo 4.0.5, so it falls back to Ubuntu 18.04
 			},
 		},
 		"arm64 ubuntu 20.04 and newer mongo": {
@@ -531,14 +531,14 @@ func TestMakeDownloadSpec(t *testing.T) {
 			etcFolder:    "ubuntu2004",
 			goArch:       "arm64",
 
-			expectedError: "memongo does not support automatic downloading on your system: Mongo doesn't support your environment, ubuntu2004/arm64, on version 4.1.0",
+			expectedError: "memongo does not support automatic downloading on your system: Mongo doesn't support your environment, ubuntu1804/arm64, on version 4.1.0", // The OS name is wrong because we don't support Ubuntu 20.04 on Mongo 4.1.0 so it falls back to Ubuntu 18.04
 		},
 		"MongoDB Unsupported older version for arm64 ubuntu2204": {
 			mongoVersion: "4.1.0",
 			etcFolder:    "ubuntu2204",
 			goArch:       "arm64",
 
-			expectedError: "memongo does not support automatic downloading on your system: Mongo doesn't support your environment, ubuntu2204/arm64, on version 4.1.0",
+			expectedError: "memongo does not support automatic downloading on your system: Mongo doesn't support your environment, ubuntu1804/arm64, on version 4.1.0", // The OS name is wrong because we don't support Ubuntu 22.04 on Mongo 4.1.0 so it falls back to Ubuntu 18.04
 		},
 		"MongoDB Unsupported older version for arm64 amazon2": {
 			mongoVersion: "4.1.0",

--- a/mongobin/getOrDownload.go
+++ b/mongobin/getOrDownload.go
@@ -63,6 +63,10 @@ func GetOrDownloadMongod(urlStr string, cachePath string, logger *memongolog.Log
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP request failed with status code %d", resp.StatusCode)
+	}
+
 	tgzTempFile, tmpFileErr := Afs.TempFile("", "")
 	if tmpFileErr != nil {
 		return "", fmt.Errorf("error creating temp file for tarball: %s", tmpFileErr)
@@ -85,8 +89,9 @@ func GetOrDownloadMongod(urlStr string, cachePath string, logger *memongolog.Log
 	// Extract mongod
 	gzReader, gzErr := gzip.NewReader(tgzTempFile)
 	if gzErr != nil {
-		return "", fmt.Errorf("error intializing gzip reader from %s: %w, %s", tgzTempFile.Name(), gzErr, urlStr)
+		return "", fmt.Errorf("error initializing gzip reader from %s: %w, %s", tgzTempFile.Name(), gzErr, urlStr)
 	}
+	defer gzReader.Close()
 
 	tarReader := tar.NewReader(gzReader)
 	for {


### PR DESCRIPTION
Ubuntu 22.04 only have their own version for 6.0.4 and above, for any mongo version below that you have to download one for a lower Ubuntu version.

This PR fixes that but also adds better error checking for a bad status code when downloading, making it easier to find the root cause of the issue _when_ one is to encounter something similar again.

